### PR TITLE
V3.0.0: Add an argument for custom separating character

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,22 @@
 'use strict';
 const modifyFilename = require('modify-filename');
 
-module.exports = (pth, hash) => {
+module.exports = (pth, hash, separatingCharacter) => {
 	if (!(pth && hash)) {
 		throw new Error('`path` and `hash` required');
 	}
 
-	return modifyFilename(pth, (filename, ext) => `${filename}-${hash}${ext}`);
+	const _separatingCharacter = separatingCharacter || '-';
+
+	return modifyFilename(pth, (filename, ext) => `${filename}${_separatingCharacter}${hash}${ext}`);
 };
 
-module.exports.revert = (pth, hash) => {
+module.exports.revert = (pth, hash, separatingCharacter) => {
 	if (!(pth && hash)) {
 		throw new Error('`path` and `hash` required');
 	}
 
-	return modifyFilename(pth, (filename, ext) => filename.replace(new RegExp(`-${hash}$`), '') + ext);
+	const _separatingCharacter = separatingCharacter || '-';
+
+	return modifyFilename(pth, (filename, ext) => filename.replace(new RegExp(`${_separatingCharacter}${hash}$`), '') + ext);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rev-path",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"description": "Create a revved file path",
 	"license": "MIT",
 	"repository": "sindresorhus/rev-path",

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,26 @@ revPath('src/unicorn.png', Date.now());
 // You can also revert an already hashed path
 revPath.revert(path, hash);
 //=> 'src/unicorn.png'
+
+// Yon can set custom separatingCharacter, default is '-'
+const path2 = revPath('src/unicorn.png', hash, '.');
+//=> 'src/unicorn.bb9d8fe615.png'
+
+const path3 = revPath('src/unicorn.png', hash, '_');
+//=> 'src/unicorn_bb9d8fe615.png'
+
+const path4 = revPath('src/unicorn.png', hash, '#');
+//=> 'src/unicorn#bb9d8fe615.png'
+
+// You can also revert an already hashed path
+revPath.revert(path2, hash, '.');
+//=> 'src/unicorn.png'
+
+revPath.revert(path3, hash, '_');
+//=> 'src/unicorn.png'
+
+revPath.revert(path4, hash, '#');
+//=> 'src/unicorn.png'
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ revPath('src/unicorn.png', Date.now());
 revPath.revert(path, hash);
 //=> 'src/unicorn.png'
 
-// Yon can set custom separatingCharacter, default is '-'
+// Yon can set custom separating character, default is '-'
 const path2 = revPath('src/unicorn.png', hash, '.');
 //=> 'src/unicorn.bb9d8fe615.png'
 

--- a/test.js
+++ b/test.js
@@ -8,4 +8,10 @@ test(t => {
 	t.is(hashed, 'src/unicorn-bb9d8fe615.png');
 	t.is(m('unicorn.png', hash), 'unicorn-bb9d8fe615.png');
 	t.is(m.revert(hashed, hash), pth);
+	t.is(m(pth, hash, '.'), 'src/unicorn.bb9d8fe615.png');
+	t.is(m.revert('src/unicorn.bb9d8fe615.png', hash, '.'), pth);
+	t.is(m(pth, hash, '_'), 'src/unicorn_bb9d8fe615.png');
+	t.is(m.revert('src/unicorn_bb9d8fe615.png', hash, '_'), pth);
+	t.is(m(pth, hash, '#'), 'src/unicorn#bb9d8fe615.png');
+	t.is(m.revert('src/unicorn#bb9d8fe615.png', hash, '#'), pth);
 });


### PR DESCRIPTION
V3.0.0:
* Add an argument for custom separating character

For example: 
* src/unicorn.bb9d8fe615.png
* src/unicorn_bb9d8fe615.png
* src/unicorn#bb9d8fe615.png

It's compatible with old usage.